### PR TITLE
OplusTypeCastingHelper & OplusThemeUtil

### DIFF
--- a/core/java/com/oplus/theme/OplusThemeUtil.java
+++ b/core/java/com/oplus/theme/OplusThemeUtil.java
@@ -1,0 +1,9 @@
+package com.oplus.theme;
+
+import android.compat.annotation.UnsupportedAppUsage;
+
+public class OplusThemeUtil {
+    /** @hide */
+    @UnsupportedAppUsage
+    public static String CUSTOM_THEME_PATH = "/data/theme/com.oplus.camera";
+}

--- a/core/java/com/oplus/util/OplusTypeCastingHelper.java
+++ b/core/java/com/oplus/util/OplusTypeCastingHelper.java
@@ -1,0 +1,3 @@
+package com.oplus.util;
+
+public final class OplusTypeCastingHelper { }

--- a/core/java/com/oplus/util/OplusTypeCastingHelper.java
+++ b/core/java/com/oplus/util/OplusTypeCastingHelper.java
@@ -1,3 +1,10 @@
 package com.oplus.util;
 
-public final class OplusTypeCastingHelper { }
+public final class OplusTypeCastingHelper {
+    public static <T> T typeCasting(Class<T> type, Object object) {
+        if (object != null && type.isInstance(object)) {
+            return type.cast(object);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Important for OnePlus Devices to run **Oplus cam** & **realme link** simultaneously. 
Oplus camera requires _OplusTypeCastingHelper_ & Realme link requires _OplusThemeUtil_

Picked from here: 
https://github.com/pjgowtham/android_frameworks_base/commit/a67df86de1ba47a2dcde797820fdd9a2b0812370 & https://github.com/crdroidandroid/android_frameworks_base/commit/4eaa2ab86b026e9f47225aefc1c1196b859164c8

Crash reports for both:
_FATAL EXCEPTION: main
Process: com.oplus.camera, PID: 19317
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/oplus/util/OplusTypeCastingHelper;
Caused by: java.lang.ClassNotFoundException: com.oplus.util.OplusTypeCastingHelper

Process: com.realme.link, PID: 13233
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/oplus/theme/OplusThemeUtil;
Caused by: java.lang.ClassNotFoundException: com.oplus.theme.OplusThemeUtil_